### PR TITLE
Update and rename create-release.yml to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,12 @@ jobs:
         uses: gittools/actions/gitversion/execute@v4
 
       - name: Create Release (tag)
-        if: ${{ steps.changes.outputs.dist == 'true' || github.event_name == 'workflow_dispatch' }}
         uses: ncipollo/release-action@v1.20.0
         with:
           allowUpdates: false
           skipIfReleaseExists: true
           draft: false
-          makeLatest: true
+          makeLatest: false
           tag: v${{ steps.gitversion.outputs.semVer }}
           name: Release v${{ steps.gitversion.outputs.semVer }}
           generateReleaseNotes: true
@@ -50,13 +49,12 @@ jobs:
             Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}
 
       - name: Create Release (latest)
-        if: ${{ steps.changes.outputs.dist == 'true' || github.event_name == 'workflow_dispatch' }}
         uses: ncipollo/release-action@v1.20.0
         with:
           allowUpdates: true
           skipIfReleaseExists: false
           draft: false
-          makeLatest: false
+          makeLatest: true
           tag: latest
           name: Release v${{ steps.gitversion.outputs.semVer }}
           generateReleaseNotes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v4
 
       - name: Create Release (tag)
+        if: ${{ steps.changes.outputs.dist == 'true' || github.event_name == 'workflow_dispatch' }}
         uses: ncipollo/release-action@v1.20.0
         with:
           allowUpdates: false
@@ -49,6 +50,7 @@ jobs:
             Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}
 
       - name: Create Release (latest)
+        if: ${{ steps.changes.outputs.dist == 'true' || github.event_name == 'workflow_dispatch' }}
         uses: ncipollo/release-action@v1.20.0
         with:
           allowUpdates: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v4
 
-      - name: Create Release
+      - name: Create Release (tag)
         if: ${{ steps.changes.outputs.dist == 'true' || github.event_name == 'workflow_dispatch' }}
         uses: ncipollo/release-action@v1.20.0
         with:
@@ -46,4 +46,19 @@ jobs:
           tag: v${{ steps.gitversion.outputs.semVer }}
           name: Release v${{ steps.gitversion.outputs.semVer }}
           generateReleaseNotes: true
-          body: Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}
+          body:
+            Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}
+
+      - name: Create Release (latest)
+        if: ${{ steps.changes.outputs.dist == 'true' || github.event_name == 'workflow_dispatch' }}
+        uses: ncipollo/release-action@v1.20.0
+        with:
+          allowUpdates: true
+          skipIfReleaseExists: false
+          draft: false
+          makeLatest: false
+          tag: latest
+          name: Release v${{ steps.gitversion.outputs.semVer }}
+          generateReleaseNotes: true
+          body:
+            Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}


### PR DESCRIPTION
## 📑 Description
Create `latest` release 

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---




## Summary by Sourcery

Rename the create-release workflow to ci.yml and enhance it by renaming the tagged release step and adding a new step to publish a 'latest' release tag

CI:
- Rename create-release GitHub Actions workflow file to ci.yml
- Rename the “Create Release” step to “Create Release (tag)”
- Add a new “Create Release (latest)” step to publish a latest release tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to support multiple release types, enabling both versioned and latest releases through improved CI/CD pipeline steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Rename the workflow from .github/workflows/create-release.yml to .github/workflows/ci.yml and split the release step into two jobs: one for the tagged release (vX.Y.Z) and one for the latest release, adjusting release options accordingly.

### Why are these changes being made?
To separate tag-based releases from the latest release flow and adjust release behavior (disable makeLatest for the tag release, enable it for the latest release) for clearer automation and safer versioning. This also aligns the workflow naming with CI processes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->