### PR TITLE
fix: update latest tag on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v4.5.0
 
       - name: Create Release (tag)
+        id: create_release
         if: ${{ steps.changes.outputs.dist == 'true' || github.event_name == 'workflow_dispatch' }}
         uses: ncipollo/release-action@v1.21.0
         with:
@@ -49,3 +50,9 @@ jobs:
           generateReleaseNotes: true
           body:
             Release ${{ steps.gitversion.outputs.semVer }} of ${{ github.event.repository.name }}
+
+      - name: Update latest tag
+        if: ${{ steps.create_release.outputs.id != '' }}
+        run: |
+          git tag --force latest
+          git push origin refs/tags/latest --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,6 @@ jobs:
       - name: Update latest tag
         if: ${{ steps.create_release.outputs.id != '' }}
         run: |
-          git tag --force latest
-          git push origin refs/tags/latest --force
+          RELEASE_TAG="v${{ steps.gitversion.outputs.semVer }}"
+          git tag --force latest "$RELEASE_TAG"
+          git push origin refs/tags/latest:refs/tags/latest --force


### PR DESCRIPTION
## Summary

- Move the `latest` Git tag to the release commit after a release is created.
- Gate the tag update on the release-action output, so skipped releases do not move `latest` by accident.
- Keep the existing `v${{ steps.gitversion.outputs.semVer }}` release tag and `makeLatest: true` release behavior.

## Why

Issue #277 notes that Renovate/Dependabot digest pinning needs an actual Git tag. The README already points users at `guibranco/github-status-action-v2@latest`, so keeping that tag current makes the documented usage resolve to the newest release commit again.

## Verification

- `npm ci`
- `npm run all` (11 AVA tests passed)
- `git diff --check` (only Windows line-ending warnings)

This was prepared with Codex assistance, with the final diff reviewed before opening.

Fixes #277.

## Summary by Sourcery

CI:
- Expose the release step output and add a gated follow-up step that force-updates and pushes the `latest` tag only when a release is actually created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release tagging automation in the CI/CD pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/github-status-action-v2/pull/278)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->